### PR TITLE
feat(remark-table-of-content): titles with styling

### DIFF
--- a/remark/table-of-content/test/index.js
+++ b/remark/table-of-content/test/index.js
@@ -6,6 +6,7 @@ import html from 'rehype-stringify'
 import extractFrontmatter from 'remark-frontmatter'
 import pluginReadFrontmatter from 'remark-read-frontmatter'
 import pluginToc from '../lib/index.js'
+import { describe, it } from 'node:test'
 
 describe('Extract table of content', () => {
   it('default', async () => {
@@ -35,7 +36,7 @@ describe('Extract table of content', () => {
         ## Heading 2
         ### Heading 3
         #### Heading 4
-      `)
+        `)
     toc.should.eql([
       { title: 'Heading 2', depth: 2, anchor: 'heading-2' },
       { title: 'Heading 3', depth: 3, anchor: 'heading-3' }
@@ -53,8 +54,8 @@ describe('Extract table of content', () => {
         #### Heading 4
         ##### Heading 5
         ###### Heading 6
-      `)
-    toc.should.eql([
+        `)
+        toc.should.eql([
       { title: 'Heading 1', depth: 1, anchor: 'heading-1' },
       { title: 'Heading 2', depth: 2, anchor: 'heading-2' },
       { title: 'Heading 3', depth: 3, anchor: 'heading-3' },
@@ -70,14 +71,47 @@ describe('Extract table of content', () => {
       .use(pluginToc, {property: ['data', 'toc']})
       .use(remark2rehype)
       .use(html).process(dedent`
-        # Heading 1
-        ## Heading 2
+      # Heading 1
+      ## Heading 2
       `)
-    data.should.eql({
-      toc: [
+      data.should.eql({
+        toc: [
         { title: 'Heading 1', depth: 1, anchor: 'heading-1' },
         { title: 'Heading 2', depth: 2, anchor: 'heading-2' }
       ]
     })
+  })
+  it('heading with styling', async () => {
+    const { toc } = await unified()
+      .use(parseMarkdown)
+      .use(pluginToc)
+      .use(remark2rehype)
+      .use(html).process(dedent`
+        # Heading 1
+        ## Heading 2
+        ## Heading 2 *italic*
+        ## Heading 2 **bold**
+        ## Heading 2 ***italic bold***
+        ## Heading 2 \`code();\`
+        ### Heading 3
+        ### Heading 3 *italic*
+        ### Heading 3 **bold**
+        ### Heading 3 ***italic bold***
+        ### Heading 3 \`code();\`
+        #### Heading 4
+      `)
+    toc.should.eql([
+      { title: 'Heading 1', depth: 1, anchor: 'heading-1' },
+      { title: 'Heading 2', depth: 2, anchor: 'heading-2' },
+      { title: 'Heading 2 italic', depth: 2, anchor: 'heading-2-italic' },
+      { title: 'Heading 2 bold', depth: 2, anchor: 'heading-2-bold' },
+      { title: 'Heading 2 italic bold', depth: 2, anchor: 'heading-2-italic-bold' },
+      { title: 'Heading 2 code();', depth: 2, anchor: 'heading-2-code' },
+      { title: 'Heading 3', depth: 3, anchor: 'heading-3' },
+      { title: 'Heading 3 italic', depth: 3, anchor: 'heading-3-italic' },
+      { title: 'Heading 3 bold', depth: 3, anchor: 'heading-3-bold' },
+      { title: 'Heading 3 italic bold', depth: 3, anchor: 'heading-3-italic-bold' },
+      { title: 'Heading 3 code();', depth: 3, anchor: 'heading-3-code' }
+    ])
   })
 })

--- a/remark/table-of-content/test/index.js
+++ b/remark/table-of-content/test/index.js
@@ -36,7 +36,7 @@ describe('Extract table of content', () => {
         ## Heading 2
         ### Heading 3
         #### Heading 4
-        `)
+      `)
     toc.should.eql([
       { title: 'Heading 2', depth: 2, anchor: 'heading-2' },
       { title: 'Heading 3', depth: 3, anchor: 'heading-3' }
@@ -54,8 +54,8 @@ describe('Extract table of content', () => {
         #### Heading 4
         ##### Heading 5
         ###### Heading 6
-        `)
-        toc.should.eql([
+      `)
+    toc.should.eql([
       { title: 'Heading 1', depth: 1, anchor: 'heading-1' },
       { title: 'Heading 2', depth: 2, anchor: 'heading-2' },
       { title: 'Heading 3', depth: 3, anchor: 'heading-3' },
@@ -71,11 +71,11 @@ describe('Extract table of content', () => {
       .use(pluginToc, {property: ['data', 'toc']})
       .use(remark2rehype)
       .use(html).process(dedent`
-      # Heading 1
-      ## Heading 2
+        # Heading 1
+        ## Heading 2
       `)
-      data.should.eql({
-        toc: [
+    data.should.eql({
+      toc: [
         { title: 'Heading 1', depth: 1, anchor: 'heading-1' },
         { title: 'Heading 2', depth: 2, anchor: 'heading-2' }
       ]


### PR DESCRIPTION
This PR should handle the case where the user has written a heading in *italic*, **bold**, ***italic bold*** or with some `code()` in it. The table of content returns the heading with no styling in it.